### PR TITLE
Adding css rule which enlarge content view of GSC

### DIFF
--- a/src.js
+++ b/src.js
@@ -135,7 +135,8 @@ seo.addCss = ()=>{
     a[rel~=nofollow] {
 	text-decoration: underline wavy red !important;
 	}
-     `
+    .shSP {max-width: none !important}';
+      `
     let head = document.head || document.getElementsByTagName('head')[0]
     let seoScriptStyle = document.createElement('style');
     seoScriptStyle.setAttribute("id", "seoScriptsMainCss");


### PR DESCRIPTION
I have added a CSS rule which set the maximum width of GSC content div to _none_.
I think it's useful when working on large monitor and it can be easily commented if don't needed.


